### PR TITLE
Use proper CMake fix for Z3's missing include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
 find_package(Z3 REQUIRED)
-find_path(Z3_INCLUDE_DIR z3++.h)
-include_directories(${Z3_INCLUDE_DIR})
+target_include_directories(z3::libz3 INTERFACE ${Z3_CXX_INCLUDE_DIRS})  # Z3 package is broken.
 
 set(core_sources
     src/Bound.cpp


### PR DESCRIPTION
Z3's CMake package is weird and doesn't always attach the include directories to the `z3::libz3` target like it should. But it _does_ always set the variable, so it can be patched around by adding it manually.

This is the right way to do it. The so-called "directory functions", `include_directories`, `add_definitions`, etc. should _never_ be used in new CMake code. Instead, one should use the modern "target functions": `target_include_directories`, `target_compile_definitions`, etc.

You should consider reading the Halide CMake contributor's guide: https://github.com/halide/Halide/blob/master/README_cmake.md#contributing-cmake-code-to-halide